### PR TITLE
当日スタッフ募集のボタンリンクの削除

### DIFF
--- a/components/template/Hero.vue
+++ b/components/template/Hero.vue
@@ -119,7 +119,7 @@ import Button from '~/components/module/Button.vue'
 }
 .l-join
 {
-  padding-top: 80px;
+  padding-top: 60px;
 }
 
 @media only screen and (min-width: 900px), print {


### PR DESCRIPTION
### 対応内容
- 当日スタッフ応募終了に伴い、スタッフ応募のボタンリンクを削除
- 参加申込みのボタンの位置を変更

### 表示
※両端が黒いのは、表示には関係なので、気にしないでくださいmm

*SP*
![スクリーンショット 2019-10-02 23 05 20](https://user-images.githubusercontent.com/35416089/66051049-3e3ca780-e569-11e9-9df5-72e369d9fee7.png)

*PC*
![スクリーンショット 2019-10-02 23 05 32](https://user-images.githubusercontent.com/35416089/66051073-485ea600-e569-11e9-81a4-795acffb0df0.png)
