### PR TITLE
Microsoft Edge で背景が真っ白になってしまう件を修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -89,6 +89,7 @@ export default {
     /*
     ** You can extend webpack config here
     */
+   transpile: ['vuetify'],
     extend(config, ctx) {
     }
   }


### PR DESCRIPTION
掲題の件で、下記のエラーが出ていたので対処しました。

```
SCRIPT1028: SCRIPT1028: Expected identifier, string or number
```

Vuetify で[既知のエラー](https://github.com/vuetifyjs/vuetify/issues/8279)のようで、Nuxt では `build.transpile` に設定する形で対応しました。現象は、 `npm run dev` で起動時には発生せず、 `npm run build` したときに発生します。

下記は Microsoft Edge で現象のキャプチャです。

![image](https://user-images.githubusercontent.com/977117/66369151-2b492d80-e9d6-11e9-86c5-ac0e3a63515d.png)
